### PR TITLE
Remove bracket colorizer VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -16,10 +16,6 @@
     // https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
     "EditorConfig.EditorConfig",
 
-    // Bracket Pair Colorizer 2
-    // https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2
-    "CoenraadS.bracket-pair-colorizer-2",
-
     // Gradle language support
     // https://marketplace.visualstudio.com/items?itemName=naco-siren.gradle-language
     "naco-siren.gradle-language",


### PR DESCRIPTION
This extension is now built-in to VS Code so we shouldn't recommend it anymore.