### PR TITLE
Upgrade to Javalin 4

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   implementation 'com.google.guava:guava:30.1-jre'
 
   // Javalin, a simple web framework for Java
-  implementation 'io.javalin:javalin:3.13.3'
+  implementation 'io.javalin:javalin:4.3.0'
 
   // Jackson, a JSON library for Java
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -26,13 +26,13 @@ public class Server {
     // API endpoints
 
     // Get specific user
-    server.get("/api/users/:id", ctx -> userController.getUser(ctx));
+    server.get("/api/users/{id}", ctx -> userController.getUser(ctx));
 
     // List users, filtered using query parameters
     server.get("/api/users", ctx -> userController.getUsers(ctx));
 
     // Get specific todo
-    server.get("/api/todos/:id", ctx -> todoController.getTodo(ctx));
+    server.get("/api/todos/{id}", ctx -> todoController.getTodo(ctx));
 
     // List todos, filtered using query parameters
     server.get("/api/todos", ctx -> todoController.getTodos(ctx));

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -29,7 +29,7 @@ public class TodoController{
    * @param ctx a Javalin HTTP context
    */
   public void getTodo(Context ctx) {
-    String id = ctx.pathParam("id", String.class).get();
+    String id = ctx.pathParam("id");
     Todo todo = todoDatabase.getTodo(id);
     if (todo != null) {
       ctx.json(todo);

--- a/server/src/main/java/umm3601/user/UserController.java
+++ b/server/src/main/java/umm3601/user/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
    * @param ctx a Javalin HTTP context
    */
   public void getUser(Context ctx) {
-    String id = ctx.pathParam("id", String.class).get();
+    String id = ctx.pathParam("id");
     User user = userDatabase.getUser(id);
     if (user != null) {
       ctx.json(user);

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -127,14 +127,14 @@ public class TodoControllerSpec {
 
   @Test
   public void GETRequestForTodoWithExistentId() throws IOException {
-    when(ctx.pathParam("id", String.class)).thenReturn(new Validator<String>("58895985a22c04e761776d54", "", "id"));
+    when(ctx.pathParam("id")).thenReturn("58895985a22c04e761776d54");
     todoController.getTodo(ctx);
     verify(ctx).status(201);
   }
 
   @Test
   public void GETRequestForTodoWithNonexistentId() throws IOException {
-    when(ctx.pathParam("id", String.class)).thenReturn(new Validator<String>("nonexistent", "", "id"));
+    when(ctx.pathParam("id")).thenReturn("nonexistent");
     Assertions.assertThrows(NotFoundResponse.class, () -> {
       todoController.getTodo(ctx);
     });

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -130,14 +130,14 @@ public class UserControllerSpec {
 
   @Test
   public void GETRequestForUserWithExistentId() throws IOException {
-    when(ctx.pathParam("id", String.class)).thenReturn(new Validator<String>("588935f5c668650dc77df581", "", "id"));
+    when(ctx.pathParam("id")).thenReturn("588935f5c668650dc77df581");
     userController.getUser(ctx);
     verify(ctx).status(201);
   }
 
   @Test
   public void GETRequestForUserWithNonexistentId() throws IOException {
-    when(ctx.pathParam("id", String.class)).thenReturn(new Validator<String>("nonexistent", "", "id"));
+    when(ctx.pathParam("id")).thenReturn("nonexistent");
     Assertions.assertThrows(NotFoundResponse.class, () -> {
       userController.getUser(ctx);
     });


### PR DESCRIPTION
This upgrades our server code to use Javalin 4. There were two main changes:

- The syntax for path params had changed, which required two small changes to `Server.java`.
- The `ctx.pathParam()` call changed in the number of arguments and its return type. This required changes in both controllers, and in both controller specs.

Closes #737