### PR TITLE
Modernize our Karma tests

### DIFF
--- a/client/src/app/users/user.service.spec.ts
+++ b/client/src/app/users/user.service.spec.ts
@@ -1,8 +1,22 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { defer } from 'rxjs';
 import { User } from './user';
 import { UserService } from './user.service';
+
+/**
+ * Create async observable that emits-once and completes
+ * after a JS engine turn.
+ */
+// This was lifted from https://stackoverflow.com/a/52959047
+// Not sure why ESLint is grumpy about it, but it should be moved
+// to some sort of utility location since it would presumably
+// be needed in many places if we go this direction. -- Nic
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+function asyncData<T>(data: T) {
+  return defer(() => Promise.resolve(data));
+}
 
 describe('UserService', () => {
   // A small collection of test users
@@ -36,10 +50,12 @@ describe('UserService', () => {
     }
   ];
   let userService: UserService;
+  let userServiceSpy: UserService;
   // These are used to mock the HTTP requests so that we (a) don't have to
   // have the server running and (b) we can check exactly which HTTP
   // requests were made to ensure that we're making the correct requests.
   let httpClient: HttpClient;
+  let httpClientSpy: jasmine.SpyObj<HttpClient>;
   let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
@@ -47,11 +63,16 @@ describe('UserService', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule]
     });
-    httpClient = TestBed.inject(HttpClient);
-    httpTestingController = TestBed.inject(HttpTestingController);
     // Construct an instance of the service with the mock
     // HTTP client.
+    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
     userService = new UserService(httpClient);
+
+    // Construct an instance of the service with the "spy"
+    // HTTP client.
+    httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
+    userServiceSpy = new UserService(httpClientSpy);
   });
 
   afterEach(() => {
@@ -61,27 +82,21 @@ describe('UserService', () => {
 
   describe('getUsers()', () => {
 
-    it('calls `api/users` when `getUsers()` is called with no parameters', () => {
-      // Assert that the users we get from this call to getUsers()
-      // should be our set of test users. Because we're subscribing
-      // to the result of getUsers(), this won't actually get
-      // checked until the mocked HTTP request 'returns' a response.
-      // This happens when we call req.flush(testUsers) a few lines
-      // down.
-      userService.getUsers().subscribe(
-        users => expect(users).toBe(testUsers)
-      );
+    it('calls `api/users` when `getUsers()` is called with no parameters', (done: DoneFn) => {
+      httpClientSpy.get.and.returnValue(asyncData(testUsers));
 
-      // Specify that (exactly) one request will be made to the specified URL.
-      const req = httpTestingController.expectOne(userService.userUrl);
-      // Check that the request made to that URL was a GET request.
-      expect(req.request.method).toEqual('GET');
-      // Check that the request had no query parameters.
-      expect(req.request.params.keys().length).toBe(0);
-      // Specify the content of the response to that request. This
-      // triggers the subscribe above, which leads to that check
-      // actually being performed.
-      req.flush(testUsers);
+      userServiceSpy.getUsers().subscribe({
+        next: users => {
+          expect(users)
+            .withContext('expected users')
+            .toEqual(testUsers);
+          done();
+        },
+        error: done.fail
+      });
+      expect(httpClientSpy.get.calls.count())
+        .withContext('one call')
+        .toBe(1);
     });
 
     describe('Calling getUsers() with parameters correctly forms the HTTP request', () => {


### PR DESCRIPTION
This basically follows the model in the Angular testing documentation (https://angular.io/guide/testing-services#testing-http-services). I haven't really thought about it very hard so I don't have a clear sense of whether I prefer this approach, or why I might, but if nothing else it better aligns with the documentation students are likely to find.