### PR TITLE
Update Angular Version warning in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ Your specific tasks for this lab can be found in the [LABTASKS.md](LABTASKS.md)
 file in this repository.
 
 > :warning: One thing to keep in mind is that the Angular developers provide two
-major updates to Angular each year. This lab is built using Angular 13. Pay attention to
+major updates to Angular each year. This lab is built using Angular 15. Pay attention to
 the version of Angular being used in examples and on-line documentation that you find. Most
 of the time, it won't matter very much, but there are times when something you find
 doesn't match what we're doing. If things seem odd, look at the versions for the
 example or documentation you're looking at just in case there's a mismatch that matters.
-
 ## Setup
 
 As in the previous lab, you'll be using VS Code and GitKraken. Once you've all joined your


### PR DESCRIPTION
Changed the warning in the README.md to match the current Angular version for the lab (15). I didn't remove it as a future proofing, in case that we don't upgrade from 15 right away.