### PR TITLE
Improve error handling when `UserProfileComponent` fails to load user

### DIFF
--- a/client/src/app/users/user-profile.component.html
+++ b/client/src/app/users/user-profile.component.html
@@ -1,5 +1,30 @@
 <div class="flex-row">
-  <div class="flex-1" fxFlex.gt-sm="80" fxFlexOffset.gt-sm="10">
-    <app-user-card [user]="this.user"></app-user-card>
+  <div class="flex-1">
+    @if (user) {
+      <app-user-card [user]="this.user"></app-user-card>
+    } @else if (error) {
+      <mat-card class="error-card">
+        <mat-card-content>
+          <h2>
+            {{ error.help }}
+          </h2>
+          <p>
+            {{ error.message }}
+          </p>
+          <p>
+            {{ error.httpResponse }}
+          </p>
+        </mat-card-content>
+        <mat-card-actions>
+          <button color=primary mat-raised-button routerLink="/users">Back to Users List</button>
+        </mat-card-actions>
+      </mat-card>
+    } @else {
+      <mat-card>
+        <mat-card-content>
+          <p>Loading User Profile data...</p>
+        </mat-card-content>
+      </mat-card>
+    }
   </div>
 </div>

--- a/client/src/app/users/user-profile.component.scss
+++ b/client/src/app/users/user-profile.component.scss
@@ -1,0 +1,6 @@
+.error-card {
+  background-color: #b00020;
+  color: white;
+  padding: 10px;
+  border-radius: 5px;
+}

--- a/client/src/app/users/user-profile.component.spec.ts
+++ b/client/src/app/users/user-profile.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatCardModule } from '@angular/material/card';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { throwError } from 'rxjs';
 import { ActivatedRouteStub } from '../../testing/activated-route-stub';
 import { MockUserService } from '../../testing/user.service.mock';
 import { User } from './user';
@@ -12,7 +13,11 @@ import { UserService } from './user.service';
 describe('UserProfileComponent', () => {
   let component: UserProfileComponent;
   let fixture: ComponentFixture<UserProfileComponent>;
-  const activatedRoute: ActivatedRouteStub = new ActivatedRouteStub();
+  const mockUserService = new MockUserService();
+  const chrisId = 'chris_id';
+  const activatedRoute: ActivatedRouteStub = new ActivatedRouteStub({
+    id: chrisId
+  });
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -22,7 +27,7 @@ describe('UserProfileComponent', () => {
         UserProfileComponent, UserCardComponent
     ],
     providers: [
-        { provide: UserService, useValue: new MockUserService() },
+        { provide: UserService, useValue: mockUserService },
         { provide: ActivatedRoute, useValue: activatedRoute }
     ]
 })
@@ -45,8 +50,6 @@ describe('UserProfileComponent', () => {
     // to update. Our `UserProfileComponent` subscribes to that, so
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
-
-    expect(component.id).toEqual(expectedUser._id);
     expect(component.user).toEqual(expectedUser);
   });
 
@@ -56,14 +59,12 @@ describe('UserProfileComponent', () => {
     // to update. Our `UserProfileComponent` subscribes to that, so
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
-
-    expect(component.id).toEqual(expectedUser._id);
+    expect(component.user).toEqual(expectedUser);
 
     // Changing the paramMap should update the displayed user profile.
     expectedUser = MockUserService.testUsers[1];
     activatedRoute.setParamMap({ id: expectedUser._id });
-
-    expect(component.id).toEqual(expectedUser._id);
+    expect(component.user).toEqual(expectedUser);
   });
 
   it('should have `null` for the user for a bad ID', () => {
@@ -72,7 +73,31 @@ describe('UserProfileComponent', () => {
     // If the given ID doesn't map to a user, we expect the service
     // to return `null`, so we would expect the component's user
     // to also be `null`.
-    expect(component.id).toEqual('badID');
     expect(component.user).toBeNull();
+  });
+
+  it('should set error data on observable error', () => {
+    activatedRoute.setParamMap({ id: chrisId });
+
+    const mockError = { message: 'Test Error', error: { title: 'Error Title' } };
+
+    // const errorResponse = { status: 500, message: 'Server error' };
+    // "Spy" on the `.addUser()` method in the user service. Here we basically
+    // intercept any calls to that method and return the error response
+    // defined above.
+    const getUserSpy = spyOn(mockUserService, 'getUserById')
+      .and
+      .returnValue(throwError(() => mockError));
+
+    // component.user = throwError(() => mockError) as Observable<User>;
+
+    component.ngOnInit();
+
+    expect(component.error).toEqual({
+      help: 'There was a problem loading the user – try again.',
+      httpResponse: mockError.message,
+      message: mockError.error.title,
+    });
+    expect(getUserSpy).toHaveBeenCalledWith(chrisId);
   });
 });

--- a/client/src/app/users/user-profile.component.ts
+++ b/client/src/app/users/user-profile.component.ts
@@ -1,20 +1,30 @@
+import { NgIf } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { ActivatedRoute, ParamMap } from '@angular/router';
+import { Subject, map, switchMap, takeUntil } from 'rxjs';
 import { User } from './user';
-import { UserService } from './user.service';
 import { UserCardComponent } from './user-card.component';
+import { UserService } from './user.service';
 
 @Component({
     selector: 'app-user-profile',
     templateUrl: './user-profile.component.html',
     styleUrls: ['./user-profile.component.scss'],
     standalone: true,
-    imports: [UserCardComponent]
+    imports: [NgIf, UserCardComponent, MatCardModule]
 })
 export class UserProfileComponent implements OnInit {
 
   user: User;
-  id: string;
+  error: { help: string, httpResponse: string, message: string }
+
+  // This `Subject` will only ever emit one (empty) value when
+  // `ngOnDestroy()` is called, i.e., when this component is
+  // destroyed. That can be used to tell any subscriptions to
+  // terminate, allowing the system to free up their resources
+  // (like memory).
+  private ngUnsubscribe = new Subject<void>();
 
   constructor(private route: ActivatedRoute, private userService: UserService) { }
 
@@ -22,9 +32,37 @@ export class UserProfileComponent implements OnInit {
     // We subscribe to the parameter map here so we'll be notified whenever
     // that changes (i.e., when the URL changes) so this component will update
     // to display the newly requested user.
-    this.route.paramMap.subscribe((paramMap) => {
-      this.id = paramMap.get('id');
-      this.userService.getUserById(this.id).subscribe(user => this.user = user);
+    this.route.paramMap.pipe(
+      // Map the paramMap into the id
+      map((paramMap: ParamMap) => paramMap.get('id')),
+      // Maps the `id` string into the Observable<User>,
+      // which will emit zero or one values depending on whether there is a
+      // `User` with that ID.
+      switchMap((id: string) => this.userService.getUserById(id)),
+      // Allow the pipeline to continue to emit values until `this.ngUnsubscribe`
+      // returns a value, which only happens when this component is destroyed.
+      // At that point we shut down the pipeline, allowed any
+      // associated resources (like memory) are cleaned up.
+      takeUntil(this.ngUnsubscribe)
+    ).subscribe({
+      next: user => {
+        this.user = user;
+        return user;
+      },
+      error: _err => {
+        this.error = {
+          help: 'There was a problem loading the user – try again.',
+          httpResponse: _err.message,
+          message: _err.error?.title,
+        };
+      }
+      /*
+       * You can uncomment the line that starts with `complete` below to use that console message
+       * as a way of verifying that this subscription is completing.
+       * We removed it since we were not doing anything interesting on completion
+       * and didn't want to clutter the console log
+       */
+      // complete: () => console.log('We got a new user, and we are done!'),
     });
   }
 

--- a/client/src/testing/user.service.mock.ts
+++ b/client/src/testing/user.service.mock.ts
@@ -58,11 +58,13 @@ export class MockUserService extends UserService {
   }
 
   getUserById(id: string): Observable<User> {
-    // If the specified ID is for the first test user,
+    // If the specified ID is for the first or second test user,
     // return that user, otherwise return `null` so
     // we can test illegal user requests.
     if (id === MockUserService.testUsers[0]._id) {
       return of(MockUserService.testUsers[0]);
+    } else if (id === MockUserService.testUsers[1]._id) {
+      return of(MockUserService.testUsers[1]);
     } else {
       return of(null);
     }


### PR DESCRIPTION
We didn't cope well when `UserProfileComponent` failed to load a user, and this makes that a bit better.

This takes care of the last thing listed on #1201 

Closes: #1201 