### PR TITLE
Bring across `Observable` handling changes from Lab 4

### DIFF
--- a/client/src/app/users/user-list.component.ts
+++ b/client/src/app/users/user-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { User, UserRole } from './user';
 import { UserService } from './user.service';
@@ -33,7 +33,7 @@ import { MatCard, MatCardTitle, MatCardContent } from '@angular/material/card';
     standalone: true,
     imports: [MatCard, MatCardTitle, MatCardContent, MatFormField, MatLabel, MatInput, FormsModule, MatHint, MatSelect, MatOption, MatRadioGroup, MatRadioButton, UserCardComponent, MatNavList, MatListSubheaderCssMatStyler, MatListItem, RouterLink, MatListItemAvatar, MatListItemTitle, MatListItemLine, MatError]
 })
-export class UserListComponent implements OnInit {
+export class UserListComponent implements OnInit, OnDestroy {
   // These are public so that tests can reference them (.spec.ts)
   public serverFilteredUsers: User[];
   public filteredUsers: User[];
@@ -63,7 +63,11 @@ export class UserListComponent implements OnInit {
    * in the GUI.
    */
   getUsersFromServer() {
+    // A user-list-component is paying attention to userService.getUsers()
+    // (which is an Observable<User[]>).
+    // (For more on Observable, see: https://reactivex.io/documentation/observable.html)
     this.userService.getUsers({
+      // Filter the users by the role and age specified in the GUI
       role: this.userRole,
       age: this.userAge
     }).pipe(
@@ -108,5 +112,14 @@ export class UserListComponent implements OnInit {
    */
   ngOnInit(): void {
     this.getUsersFromServer();
+  }
+
+  /**
+   * When this component is destroyed, we should unsubscribe to any
+   * outstanding requests.
+   */
+  ngOnDestroy() {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
   }
 }

--- a/client/src/app/users/user-profile.component.html
+++ b/client/src/app/users/user-profile.component.html
@@ -1,5 +1,9 @@
 <div class="flex-row">
   <div class="flex-1" fxFlex.gt-sm="80" fxFlexOffset.gt-sm="10">
-    <app-user-card [user]="this.user"></app-user-card>
+    @if (this.user) {
+      <app-user-card [user]="this.user"></app-user-card>
+    } @else {
+      <p>Loading user profile data...</p>
+    }
   </div>
 </div>

--- a/client/src/app/users/user-profile.component.spec.ts
+++ b/client/src/app/users/user-profile.component.spec.ts
@@ -46,7 +46,6 @@ describe('UserProfileComponent', () => {
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
 
-    expect(component.id).toEqual(expectedUser._id);
     expect(component.user).toEqual(expectedUser);
   });
 
@@ -57,13 +56,13 @@ describe('UserProfileComponent', () => {
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
 
-    expect(component.id).toEqual(expectedUser._id);
+    expect(component.user).toEqual(expectedUser);
 
     // Changing the paramMap should update the displayed user profile.
     expectedUser = MockUserService.testUsers[1];
     activatedRoute.setParamMap({ id: expectedUser._id });
 
-    expect(component.id).toEqual(expectedUser._id);
+    expect(component.user).toEqual(expectedUser);
   });
 
   it('should have `null` for the user for a bad ID', () => {
@@ -72,7 +71,6 @@ describe('UserProfileComponent', () => {
     // If the given ID doesn't map to a user, we expect the service
     // to return `null`, so we would expect the component's user
     // to also be `null`.
-    expect(component.id).toEqual('badID');
     expect(component.user).toBeNull();
   });
 });

--- a/client/src/app/users/user-profile.component.ts
+++ b/client/src/app/users/user-profile.component.ts
@@ -1,8 +1,10 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, ParamMap } from '@angular/router';
 import { User } from './user';
 import { UserService } from './user.service';
 import { UserCardComponent } from './user-card.component';
+import { Subject, map, switchMap, takeUntil } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
     selector: 'app-user-profile',
@@ -11,21 +13,71 @@ import { UserCardComponent } from './user-card.component';
     standalone: true,
     imports: [UserCardComponent]
 })
-export class UserProfileComponent implements OnInit {
+export class UserProfileComponent implements OnInit, OnDestroy {
 
   user: User;
-  id: string;
+  // This `Subject` will only ever emit one (empty) value when
+  // `ngOnDestroy()` is called, i.e., when this component is
+  // destroyed. That can be used ot tell any subscriptions to
+  // terminate, allowing the system to free up their resources (like memory).
+  private ngUnsubscribe = new Subject<void>();
 
-  constructor(private route: ActivatedRoute, private userService: UserService) { }
+  constructor(
+    private route: ActivatedRoute,
+    private userService: UserService,
+    private snackBar: MatSnackBar) { }
 
   ngOnInit(): void {
-    // We subscribe to the parameter map here so we'll be notified whenever
-    // that changes (i.e., when the URL changes) so this component will update
-    // to display the newly requested user.
-    this.route.paramMap.subscribe((paramMap) => {
-      this.id = paramMap.get('id');
-      this.userService.getUserById(this.id).subscribe(user => this.user = user);
+    // The `map`, `switchMap`, and `takeUntil` are all RXJS operators, and
+    // each represents a step in the pipeline built using the RXJS `pipe`
+    // operator.
+    // The map step takes the `ParamMap` from the `ActivatedRoute`, which
+    // is typically the URL in the browser bar.
+    // The result from the map step is the `id` string for the requested
+    // `User`.
+    // That ID string gets passed (by `pipe`) to `switchMap`, which transforms
+    // it into an Observable<User>, i.e., all the (zero or one) `User`s
+    // that have that ID.
+    // The `takeUntil` operator allows this pipeline to continue to emit values
+    // until `this.ngUnsubscribe` emits a value, saying to shut the pipeline
+    // down and clean up any associated resources (like memory).
+    this.route.paramMap.pipe(
+      // Map the paramMap into the id
+      map((paramMap: ParamMap) => paramMap.get('id')),
+      // Maps the `id` string into the Observable<User>,
+      // which will emit zero or one values depending on whether there is a
+      // `User` with that ID.
+      switchMap((id: string) => this.userService.getUserById(id)),
+      // Allow the pipeline to continue to emit values until `this.ngUnsubscribe`
+      // returns a value, which only happens when this component is destroyed.
+      // At that point we shut down the pipeline, allowed any
+      // associated resources (like memory) are cleaned up.
+      takeUntil(this.ngUnsubscribe)
+    ).subscribe({
+      next: user => this.user = user,
+      error: () => {
+        this.snackBar.open('Problem loading the user – try again', 'OK', {
+          duration: 5000,
+        });
+      }
+      /*
+       * You can uncomment the line that starts with `complete` below to use that console message
+       * as a way of verifying that this subscription is completing.
+       * We removed it since we were not doing anything interesting on completion
+       * and didn't want to clutter the console log
+       */
+      // complete: () => console.log('We got a new user, and we are done!'),
     });
   }
 
+  ngOnDestroy() {
+    // When the component is destroyed, we'll emit an empty
+    // value as a way of saying that any active subscriptions should
+    // shut themselves down so the system can free up any associated
+    // resources, like memory.
+    this.ngUnsubscribe.next();
+    // Calling `complete()` says that this `Subject` is done and will
+    // never send any further values.
+    this.ngUnsubscribe.complete();
+  }
 }

--- a/client/src/testing/user.service.mock.ts
+++ b/client/src/testing/user.service.mock.ts
@@ -58,11 +58,15 @@ export class MockUserService extends UserService {
   }
 
   getUserById(id: string): Observable<User> {
-    // If the specified ID is for the first test user,
+    // If the specified ID is for one of the test users,
     // return that user, otherwise return `null` so
     // we can test illegal user requests.
     if (id === MockUserService.testUsers[0]._id) {
       return of(MockUserService.testUsers[0]);
+    } else if (id === MockUserService.testUsers[1]._id) {
+      return of(MockUserService.testUsers[1]);
+    } else if (id === MockUserService.testUsers[2]._id) {
+      return of(MockUserService.testUsers[2]);
     } else {
       return of(null);
     }


### PR DESCRIPTION
This improves our handling of `Observable`s in a variety of ways, mostly copying from https://github.com/UMM-CSci-3601/3601-lab4-mongo/pull/68