### PR TITLE
Copy `dependabot.yml` over from iteration template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,145 +1,37 @@
 version: 2
 updates:
-- package-ecosystem: gradle
-  directory: "/server"
-  schedule:
-    interval: monthly
-    time: "12:00"
-    timezone: America/Chicago
-  open-pull-requests-limit: 50
-  ignore:
-  - dependency-name: org.mockito:mockito-core
-    versions:
-    - 3.6.28
-    - 3.7.7
-  - dependency-name: io.javalin:javalin
-    versions:
-    - 3.12.0
-    - 3.13.3
-  - dependency-name: com.fasterxml.jackson.core:jackson-databind
-    versions:
-    - 2.12.0
-    - 2.12.1
-  - dependency-name: com.google.guava:guava
-    versions:
-    - 30.1-jre
-  - dependency-name: org.junit.jupiter:junit-jupiter-engine
-    versions:
-    - 5.7.0
-  - dependency-name: org.junit.jupiter:junit-jupiter-api
-    versions:
-    - 5.7.0
 - package-ecosystem: npm
   directory: "/client"
   schedule:
-    interval: monthly
+    interval: weekly
     time: "12:00"
     timezone: America/Chicago
-  open-pull-requests-limit: 50
-  ignore:
-  - dependency-name: "@angular/cli"
-    versions:
-    - 11.0.5
-    - 11.1.2
-    - 11.2.2
-  - dependency-name: "@typescript-eslint/parser"
-    versions:
-    - 4.16.0
-  - dependency-name: "@nrwl/cypress"
-    versions:
-    - 11.4.0
-  - dependency-name: "@angular-devkit/build-angular"
-    versions:
-    - 0.1102.2
-    - 0.901.13
-  - dependency-name: "@typescript-eslint/eslint-plugin"
-    versions:
-    - 4.16.0
-  - dependency-name: eslint-plugin-jsdoc
-    versions:
-    - 32.2.0
-  - dependency-name: "@nrwl/workspace"
-    versions:
-    - 11.4.0
-  - dependency-name: "@types/jasmine"
-    versions:
-    - 3.6.2
-    - 3.6.3
-    - 3.6.4
-  - dependency-name: cypress
-    versions:
-    - 6.5.0
-  - dependency-name: "@angular/language-service"
-    versions:
-    - 11.0.5
-    - 11.1.1
-    - 11.2.3
-  - dependency-name: eslint
-    versions:
-    - 7.21.0
-  - dependency-name: rxjs
-    versions:
-    - 6.6.3
-    - 6.6.6
-  - dependency-name: "@types/node"
-    versions:
-    - 14.14.19
-    - 14.14.22
-    - 14.14.28
-    - 14.14.31
-  - dependency-name: jasmine-spec-reporter
-    versions:
-    - 6.0.0
-  - dependency-name: zone.js
-    versions:
-    - 0.10.3
-    - 0.11.3
-  - dependency-name: ts-node
-    versions:
-    - 9.1.1
-  - dependency-name: karma-jasmine-html-reporter
-    versions:
-    - 1.5.4
-  - dependency-name: karma
-    versions:
-    - 5.2.3
-    - 6.0.3
-  - dependency-name: acorn
-    versions:
-    - 6.4.2
-  - dependency-name: tslib
-    versions:
-    - 1.14.1
-  - dependency-name: codelyzer
-    versions:
-    - 6.0.1
-  - dependency-name: http-proxy
-    versions:
-    - 1.18.1
-  - dependency-name: karma-jasmine
-    versions:
-    - 4.0.1
-  - dependency-name: dot-prop
-    versions:
-    - 4.2.1
-  - dependency-name: npm-registry-fetch
-    versions:
-    - 4.0.7
-  - dependency-name: lodash
-    versions:
-    - 4.17.20
-  - dependency-name: elliptic
-    versions:
-    - 6.5.3
-  - dependency-name: protractor
-    versions:
-    - 7.0.0
-  - dependency-name: karma-coverage-istanbul-reporter
-    versions:
-    - 3.0.3
-  - dependency-name: websocket-extensions
-    versions:
-    - 0.1.4
-  - dependency-name: tslint
-    versions:
-    - 5.20.1
+  open-pull-requests-limit: 20
+- package-ecosystem: gradle
+  directory: "/server"
+  schedule:
+    interval: weekly
+    time: "12:00"
+    timezone: America/Chicago
+  open-pull-requests-limit: 20
+- package-ecosystem: docker
+  directory: "/server"
+  schedule:
+    interval: weekly
+    time: "12:00"
+    timezone: America/Chicago
+  open-pull-requests-limit: 20
+- package-ecosystem: docker
+  directory: "/client"
+  schedule:
+    interval: weekly
+    time: "12:00"
+    timezone: America/Chicago
+  open-pull-requests-limit: 20
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "12:00"
+    timezone: America/Chicago
+  open-pull-requests-limit: 20


### PR DESCRIPTION
The `dependabot.yml` file was super specific to particular versions, which I think was to reduce the noise from Dependabot updates on this repo since's it's sorta a combo copy of Labs 2 and the iteration template. That said, it wasn't being updated consistently, so I just copied things over from the iteration template.

I think the _real_ solution here is bringing all the labs repos into a mono-repo, and then we would only have one version of all these dependencies to update.

Closes: #1072 